### PR TITLE
Fix mnemonics

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,13 +1,11 @@
 [
     {
-        "caption": "File",
-        "mnemonic": "f",
         "id": "file",
         "children":
         [
             {
                 "caption": "Save Copy As...",
-                "mnemonic": "k",
+                "mnemonic": "s",
                 "command": "save_copy_as"
             }
         ]


### PR DESCRIPTION
These mnemonics do not seem to work, and will trigger loads of warnings in the Sublime 3 console (View --> Show Console)

```
warning: mnemonic f not found in menu caption File
warning: mnemonic k not found in menu caption Save Copy As...
```

See https://github.com/NickHatBoecker/SaveCopyAs/issues/3

I removed the overwrite for `File` and added `s` as mnemonic.